### PR TITLE
[codex] Harden session diagnostics logging

### DIFF
--- a/src/utils/sessionDiagnostics.ts
+++ b/src/utils/sessionDiagnostics.ts
@@ -1,14 +1,6 @@
-import { createHash } from 'node:crypto';
-
 import type { HejSession } from '../types.js';
 
 const REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
-
-export interface SecretPreview {
-  prefix4: string;
-  length: number;
-  sha256_8: string;
-}
 
 export interface SessionLogContext {
   identifierType: 'email' | 'phone';
@@ -19,8 +11,8 @@ export interface SessionLogContext {
   expiresInMs: number;
   refreshRecommendedAt: number;
   refreshRecommendedAtIso: string;
-  accessTokenPreview: SecretPreview;
-  sessionCookiePreview: SecretPreview;
+  accessTokenPresent: boolean;
+  sessionCookiePresent: boolean;
 }
 
 export function createSessionLogContext(session: HejSession, nowMs = Date.now()): SessionLogContext {
@@ -35,16 +27,8 @@ export function createSessionLogContext(session: HejSession, nowMs = Date.now())
     expiresInMs: Math.max(0, session.expiresAt - nowMs),
     refreshRecommendedAt,
     refreshRecommendedAtIso: toIso(refreshRecommendedAt),
-    accessTokenPreview: previewSecret(session.accessToken),
-    sessionCookiePreview: previewSecret(session.jsessionId),
-  };
-}
-
-function previewSecret(value: string): SecretPreview {
-  return {
-    prefix4: value.slice(0, 4),
-    length: value.length,
-    sha256_8: createHash('sha256').update(value).digest('hex').slice(0, 8),
+    accessTokenPresent: session.accessToken.length > 0,
+    sessionCookiePresent: session.jsessionId.length > 0,
   };
 }
 

--- a/tests/session-diagnostics.test.ts
+++ b/tests/session-diagnostics.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, test } from 'vitest';
 import { createSessionLogContext } from '../src/utils/sessionDiagnostics.js';
 
 describe('session diagnostics', () => {
-  test('summarizes session expiry and secret previews without leaking raw values', () => {
+  test('summarizes session expiry without exposing secret previews or fingerprints', () => {
     const context = createSessionLogContext({
       identifier: 'user@example.test',
       autoLogin: true,
-      accessToken: 'access-token-secret',
-      jsessionId: 'session-cookie-secret',
+      accessToken: 'top-token-secret',
+      jsessionId: 'jar-cookie-secret',
       usernameCookie: 'username-cookie-secret',
       expiresAt: Date.UTC(2026, 5, 2, 12, 0, 0),
     }, Date.UTC(2026, 5, 1, 12, 0, 0));
@@ -19,17 +19,16 @@ describe('session diagnostics', () => {
       expiresAt: Date.UTC(2026, 5, 2, 12, 0, 0),
       expiresAtIso: '2026-06-02T12:00:00.000Z',
       refreshRecommendedAtIso: '2026-06-01T12:00:00.000Z',
-      accessTokenPreview: {
-        prefix4: 'acce',
-        length: 19,
-      },
-      sessionCookiePreview: {
-        prefix4: 'sess',
-        length: 21,
-      },
+      accessTokenPresent: true,
+      sessionCookiePresent: true,
     });
-    expect(JSON.stringify(context)).not.toContain('access-token-secret');
-    expect(JSON.stringify(context)).not.toContain('session-cookie-secret');
+    expect(context).not.toHaveProperty('accessTokenPreview');
+    expect(context).not.toHaveProperty('sessionCookiePreview');
+    expect(JSON.stringify(context)).not.toContain('top-token-secret');
+    expect(JSON.stringify(context)).not.toContain('jar-cookie-secret');
+    expect(JSON.stringify(context)).not.toContain('top-');
+    expect(JSON.stringify(context)).not.toContain('jar-');
+    expect(JSON.stringify(context)).not.toContain('sha256');
     expect(JSON.stringify(context)).not.toContain('user@example.test');
   });
 });


### PR DESCRIPTION
## Summary
- Replaces deterministic access token and session cookie previews in session diagnostics with boolean presence fields.
- Removes the SHA-256 fingerprinting path that CodeQL flagged as insufficient password hashing.
- Updates the regression test to assert raw secrets, prefixes, and hash field names are not emitted.

## Root Cause
CodeQL traced login credentials through the session diagnostics helper because it hashed secret-derived values with fast SHA-256 for log correlation. Even truncated deterministic fingerprints are unnecessary for this diagnostic path.

## Test Plan
- npm run lint
- npm run typecheck
- npm test
- npm run test:ui
- npm run build
- npm run docs:check
- npm pack --dry-run
- git diff --check