### PR TITLE
Fix RelayController power1 control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chazepps/homebridge-hejhome",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chazepps/homebridge-hejhome",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chazepps/homebridge-hejhome",
   "displayName": "Hejhome",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "description": "The Hejhome plugin allows you to access your Hejhome device(s) from HomeKit.",
   "author": {

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -56,6 +56,8 @@ export class HejhomePlatformAccessory {
         this.updatePowerServices(device, this.switchPowerKeys(device), this.platform.Service.Switch);
         break;
       case 'relay-switch':
+        this.updatePowerService(device, this.relayPowerKey(device), this.platform.Service.Switch);
+        break;
       case 'ir-switch':
         this.updatePowerService(device, 'power', this.platform.Service.Switch);
         break;
@@ -114,6 +116,8 @@ export class HejhomePlatformAccessory {
         this.configurePowerServices(this.switchPowerKeys(this.device), this.platform.Service.Switch, '스위치');
         break;
       case 'relay-switch':
+        this.configurePowerService(this.platform.Service.Switch, this.relayPowerKey(this.device), this.device.name);
+        break;
       case 'ir-switch':
         this.configurePowerService(this.platform.Service.Switch, 'power', this.device.name);
         break;
@@ -600,6 +604,10 @@ export class HejhomePlatformAccessory {
     const match = /(?:Zigbee)?Switch(\d+)/.exec(device.deviceType);
     const count = match?.[1] ? Number(match[1]) : countPowerKeys(device.deviceState);
     return powerKeys(Math.max(1, count));
+  }
+
+  private relayPowerKey(device: HejDevice): PowerKey {
+    return device.deviceState?.power !== undefined ? 'power' : 'power1';
   }
 
   private powerStripKeys(device: HejDevice): PowerKey[] {

--- a/tests/platform-accessory.test.ts
+++ b/tests/platform-accessory.test.ts
@@ -285,6 +285,29 @@ describe('HejhomePlatformAccessory', () => {
     }
   });
 
+  test('controls RelayController devices with the observed power1 datapoint', async () => {
+    const platform = createPlatformMock();
+    const accessory = createAccessoryMock('렉 환풍기', 'uuid:relay-1', platform);
+    const client = createClientMock();
+    const device = deviceFixture({
+      id: 'relay-1',
+      name: '렉 환풍기',
+      deviceType: 'RelayController',
+      modelName: 'LKW-RC031',
+      deviceState: {
+        power1: false,
+      },
+    });
+
+    new HejhomePlatformAccessory(platform, accessory, device, client);
+
+    const relayService = accessory.service('Switch');
+    await expect(relayService?.characteristic('On').getValue()).resolves.toBe(false);
+    await relayService?.characteristic('On').setValue(true);
+
+    expect(client.controlDevice).toHaveBeenCalledWith('relay-1', { power1: true });
+  });
+
   test('exposes multi-gang switches as separate switch services', async () => {
     const platform = createPlatformMock();
     const accessory = createAccessoryMock('거실 스위치', 'uuid:switch-1', platform);


### PR DESCRIPTION
## What changed

- select the relay control datapoint from the discovered device state
- preserve `power` for relay variants that expose it and use the established `power1` contract for `RelayController`
- add a regression test covering HomeKit `On` → `{ power1: true }`
- bump the package version to `2.0.1`

## Root cause

The v2 accessory rewrite grouped relay and IR switch handling together and hard-coded the `power` datapoint. `RelayController` devices expose and accept `power1`, as the v1 implementation and production device snapshot both show, so Hejhome rejected the v2 request with HTTP 400.

## Validation

- verified the regression test fails before the fix with received `{ power: true }`
- `npm run verify`: lint, typecheck, 53 Vitest tests, 8 Playwright tests, build, and docs checks passed
- deployed the packed `2.0.1` artifact to CZMM (`10.10.10.151`)
- child bridge loaded plugin v2.0.1 without initialization errors
- live `GKW-RC031` relay test: `power1` ON returned HTTP 200 and state became true; restore returned HTTP 200 and state returned to false

Closes #20
