### PR TITLE
Hejhome 로그인/REST를 goqual.io OpenAPI로 전환

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -14,13 +14,11 @@ This directory records the Hejhome Web API behavior used by the plugin. It inten
 
 | Purpose | Method | Endpoint Pattern | Notes |
 | --- | --- | --- | --- |
-| User profile | GET | `dashboard/config/user` | Used to confirm account identity and camera access metadata. |
-| Home list | GET | `dashboard/family` | Returns homes with numeric `familyId` and display name. |
-| Room list | GET | `dashboard/rooms/{familyId}` | Returns rooms for a home. |
-| Device state | GET | `dashboard/{familyId}/devices-state?scope=shop` | Returns all devices for a home. |
-| Room device state | GET | `dashboard/{familyId}/room/{roomId}/devices-state?scope=shop` | Returns devices scoped to one room. |
-| Device command | POST | `dashboard/control/{deviceId}` | Body contains `requirments`, matching the web API spelling. |
-| Camera list | GET | `dashboard/devices/camera` | Returns camera devices separately from normal device state discovery. |
+| Device list | GET | `openapi/devices` | Returns the account device list. Home and room membership are derived from `familyId` / `roomId` when present. |
+| Home list | derived | `openapi/devices` | Numeric homes are grouped from device `familyId`. A single virtual home is used when those fields are absent. |
+| Room list | derived | `openapi/devices` | Rooms are grouped from device `roomId` within a home. |
+| Device command | POST | `openapi/control/{deviceId}` | Body contains `requirments`, matching the upstream API spelling. |
+| Camera list | GET | `dashboard/devices/camera` | Deferred camera discovery path. Not used by current accessory discovery. |
 | Camera WebRTC config | GET | `dashboard/webrtc/configs/{deviceId}` | Returns ICE/auth/signaling metadata for a camera. |
 | Camera access config | POST | `dashboard/webrtc/access-config` | Creates short-lived MQTT/WebRTC signaling access data. |
 

--- a/docs/generated/project-structure/monorepo.md
+++ b/docs/generated/project-structure/monorepo.md
@@ -101,6 +101,7 @@ Generated from the current repository tree. Generated project-structure snapshot
 │   ├── fixtures
 │   │   └── pi-devices-snapshot.json
 │   ├── hej-auth.test.ts
+│   ├── hej-rest.test.ts
 │   ├── homebridge-dev-ui.test.ts
 │   ├── log-store.test.ts
 │   ├── official-gates.test.ts

--- a/docs/references/hej-web-packet-map.md
+++ b/docs/references/hej-web-packet-map.md
@@ -5,9 +5,11 @@
 | Flow | Endpoint Pattern | Notes |
 | --- | --- | --- |
 | Email verification send | `2factor.goqual.com` email send path | Captured from Hejhome Web traffic and stored only as redacted flow |
-| Password login | `square.hej.so` OAuth login path | Uses request-time OAuth authorization headers |
-| Authorization code | `square.hej.so` OAuth authorize path | Auto-login cookie state is included |
-| Token exchange | `square.hej.so` OAuth token path | Access token is parsed and persisted through `SessionStore` |
+| Password login | `goqual.io` OAuth login path with `vendor=openapi` | Uses request-time Basic authorization and an empty JSON body |
+| Authorization code | `goqual.io` OAuth authorize path | Session cookie from login is included; `redirect_uri` is `square.hej.so/list` and scope is `shop` |
+| Token exchange | `goqual.io` OAuth token path | Uses the same `redirect_uri` as authorize; access token is persisted through `SessionStore` |
+| Device list | `goqual.io` OpenAPI devices path | Homes and rooms are derived from the device list when family endpoints are absent |
+| Device command | `goqual.io` OpenAPI control path | Body contains `requirments`, matching the upstream spelling |
 
 ## Inferred
 

--- a/docs/references/project-map.md
+++ b/docs/references/project-map.md
@@ -27,6 +27,7 @@
 | --- | --- |
 | `tests/official-gates.test.ts` | Homebridge package and schema gates |
 | `tests/hej-auth.test.ts` | Authentication request flow |
+| `tests/hej-rest.test.ts` | OpenAPI device list, home/room derivation, and control |
 | `tests/session-store.test.ts` | Storage persistence |
 | `tests/redaction.test.ts` | Secret masking |
 | `tests/platform.test.ts` | Unconfigured platform behavior |

--- a/src/hej/auth.ts
+++ b/src/hej/auth.ts
@@ -2,9 +2,11 @@ import type { HejSession } from '../types.js';
 
 export const HEJ_CLIENT_ID = '62f4020744ca4510827d3b4a4d2c7e7f';
 export const HEJ_CLIENT_SECRET = 'fcd4302cece447a9ab009296f649d2c0';
+export const GOQUAL_ORIGIN = 'https://goqual.io';
+export const SQUARE_ORIGIN = 'https://square.hej.so';
 
-const SQUARE_ORIGIN = 'https://square.hej.so';
 const TWO_FACTOR_ORIGIN = 'https://2factor.goqual.com';
+const AUTHORIZE_REDIRECT_URI = `${SQUARE_ORIGIN}/list`;
 
 export interface LoginRequest {
   identifier: string;
@@ -76,19 +78,18 @@ export class HejAuthClient {
       throw new Error('Hejhome password is required');
     }
 
-    const loginResponse = await this.fetchWithTiming('oauth.login', `${SQUARE_ORIGIN}/oauth/login?vendor=shop`, {
+    const loginResponse = await this.fetchWithTiming('oauth.login', `${GOQUAL_ORIGIN}/oauth/login?vendor=openapi`, {
       method: 'POST',
       headers: {
-        accept: 'text/plain, */*; q=0.01',
-        'accept-language': 'ko-kr',
+        accept: 'application/json, text/plain, */*',
         authorization: makeBasicAuth(request.identifier, request.password),
-        'content-type': 'application/x-www-form-urlencoded',
-        'x-requested-with': 'XMLHttpRequest, XMLHttpRequest',
+        'content-type': 'application/json',
       },
+      body: '{}',
     });
     await ensureOk(loginResponse, 'Failed to login to Hejhome');
 
-    const jsessionId = parseJSessionId(loginResponse.headers.get('set-cookie'));
+    const jsessionId = parseJSessionId(loginResponse.headers);
     if (!jsessionId) {
       throw new Error('Hejhome login did not return a session cookie');
     }
@@ -108,9 +109,9 @@ export class HejAuthClient {
   }
 
   private async getAuthorizationCode(usernameCookie: string, jsessionId: string): Promise<string> {
-    const authorizeUrl = `${SQUARE_ORIGIN}/oauth/authorize?${new URLSearchParams({
+    const authorizeUrl = `${GOQUAL_ORIGIN}/oauth/authorize?${new URLSearchParams({
       client_id: HEJ_CLIENT_ID,
-      redirect_uri: `${SQUARE_ORIGIN}/list`,
+      redirect_uri: AUTHORIZE_REDIRECT_URI,
       response_type: 'code',
       scope: 'shop',
     }).toString()}`;
@@ -121,10 +122,13 @@ export class HejAuthClient {
         cookie: `username=${usernameCookie}; JSESSIONID=${jsessionId}; autoLogin=true`,
       },
     });
-    const location = response.headers.get('location') ?? response.url;
-    const code = location ? new URL(location, SQUARE_ORIGIN).searchParams.get('code') : null;
+    const bodyText = await response.text().catch(() => '');
+    const code = extractAuthorizationCode(response, bodyText);
     if (!code) {
-      throw new Error('Hejhome authorization did not return an OAuth code');
+      const snippet = bodyText.replace(/\s+/g, ' ').trim().slice(0, 160);
+      throw new Error(
+        `Hejhome authorization did not return an OAuth code (HTTP ${response.status}${snippet ? ` ${snippet}` : ''})`,
+      );
     }
     return code;
   }
@@ -134,20 +138,19 @@ export class HejAuthClient {
     usernameCookie: string,
     jsessionId: string,
   ): Promise<{ accessToken: string; expiresIn: number }> {
-    const response = await this.fetchWithTiming('oauth.token', `${SQUARE_ORIGIN}/oauth/token`, {
+    const response = await this.fetchWithTiming('oauth.token', `${GOQUAL_ORIGIN}/oauth/token`, {
       method: 'POST',
       headers: {
         accept: 'application/json, text/javascript, */*; q=0.01',
         authorization: makeBasicAuth(HEJ_CLIENT_ID, HEJ_CLIENT_SECRET),
         'content-type': 'application/x-www-form-urlencoded',
         cookie: `username=${usernameCookie}; JSESSIONID=${jsessionId}; autoLogin=true`,
-        'x-requested-with': 'XMLHttpRequest',
       },
       body: new URLSearchParams({
         grant_type: 'authorization_code',
         code,
         client_id: HEJ_CLIENT_ID,
-        redirect_uri: `${SQUARE_ORIGIN}/list`,
+        redirect_uri: AUTHORIZE_REDIRECT_URI,
       }),
     });
     await ensureOk(response, 'Failed to exchange Hejhome OAuth code');
@@ -179,7 +182,7 @@ export class HejAuthClient {
       });
       this.emitLog({
         phase,
-        status: 'success',
+        status: response.status >= 400 ? 'error' : 'success',
         durationMs: this.now() - startedAt,
         httpStatus: response.status,
       });
@@ -226,8 +229,51 @@ function makeBasicAuth(id: string, password: string): string {
   return `Basic ${Buffer.from(`${id}:${password}`, 'utf8').toString('base64')}`;
 }
 
-function parseJSessionId(setCookie: string | null): string | null {
-  return setCookie?.match(/JSESSIONID=([^;]+)/)?.[1] ?? null;
+function parseJSessionId(headers: Headers): string | null {
+  const cookies = typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : [];
+  for (const cookie of cookies) {
+    const match = cookie.match(/JSESSIONID=([^;]+)/i);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return headers.get('set-cookie')?.match(/JSESSIONID=([^;]+)/i)?.[1] ?? null;
+}
+
+function extractAuthorizationCode(response: Response, bodyText: string): string | null {
+  const candidates = [response.headers.get('location'), response.url];
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+    try {
+      const code = new URL(candidate, SQUARE_ORIGIN).searchParams.get('code');
+      if (code) {
+        return code;
+      }
+    } catch {
+      // Ignore values that are not URLs.
+    }
+  }
+
+  if (response.status >= 400) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(bodyText) as { code?: unknown };
+    if (typeof parsed.code === 'string' && parsed.code) {
+      return parsed.code;
+    }
+  } catch {
+    // Body is not JSON.
+  }
+
+  const trimmed = bodyText.trim().replace(/^"|"$/g, '');
+  if (trimmed && /^[A-Za-z0-9._~+/-]+=*$/.test(trimmed) && trimmed.length <= 256 && !trimmed.includes('{')) {
+    return trimmed;
+  }
+  return null;
 }
 
 async function ensureOk(response: Response, message: string): Promise<void> {

--- a/src/hej/rest.ts
+++ b/src/hej/rest.ts
@@ -1,7 +1,9 @@
 import type { HejDevice, HejFamily, HejRoom, HejSession } from '../types.js';
+import { GOQUAL_ORIGIN } from './auth.js';
 import { sanitizeForLog } from '../utils/redact.js';
 
-const SQUARE_ORIGIN = 'https://square.hej.so';
+export const HEJ_VIRTUAL_FAMILY_ID = 1;
+const HEJ_VIRTUAL_FAMILY_NAME = 'Hejhome';
 
 export interface HejRestLogEvent {
   path: string;
@@ -17,16 +19,6 @@ export interface HejRestClientOptions {
   logger?: (event: HejRestLogEvent) => void;
   now?: () => number;
   requestTimeoutMs?: number;
-}
-
-interface FamilyListResponse {
-  result: HejFamily[];
-}
-
-interface RoomListResponse {
-  result: {
-    rooms: HejRoom[];
-  };
 }
 
 export class HejRestClient {
@@ -46,18 +38,27 @@ export class HejRestClient {
   }
 
   async getFamilies(): Promise<HejFamily[]> {
-    const response = await this.request<FamilyListResponse>('dashboard/family');
-    return response.result;
+    return familiesFromDevices(await this.listDevices());
   }
 
   async getRooms(familyId: number): Promise<HejRoom[]> {
-    const response = await this.request<RoomListResponse>(`dashboard/rooms/${familyId}`);
-    return response.result.rooms;
+    return roomsFromDevices(await this.listDevices(), familyId);
   }
 
   async getDevices(familyId: number, roomId?: number | 'all'): Promise<HejDevice[]> {
-    const roomSegment = roomId === undefined ? '' : `/room/${roomId}`;
-    return this.request<HejDevice[]>(`dashboard/${familyId}${roomSegment}/devices-state?scope=shop`);
+    const devices = await this.listDevices();
+    return devices.filter((device) => {
+      if (assignedFamilyId(device) !== familyId) {
+        return false;
+      }
+      if (roomId === undefined || roomId === 'all') {
+        return true;
+      }
+      return device.roomId === roomId;
+    }).map((device) => ({
+      ...device,
+      familyId: assignedFamilyId(device),
+    }));
   }
 
   async getCameraDevices(): Promise<unknown[]> {
@@ -76,10 +77,15 @@ export class HejRestClient {
   }
 
   async controlDevice(deviceId: string, requirements: Record<string, unknown>): Promise<void> {
-    await this.requestText(`dashboard/control/${deviceId}`, {
+    await this.requestText(`openapi/control/${deviceId}`, {
       method: 'POST',
       body: JSON.stringify({ requirments: requirements }),
     });
+  }
+
+  private async listDevices(): Promise<HejDevice[]> {
+    const text = await this.requestText('openapi/devices', { method: 'GET' });
+    return normalizeOpenApiDevices(JSON.parse(text || 'null'));
   }
 
   private async request<T>(path: string): Promise<T> {
@@ -97,7 +103,7 @@ export class HejRestClient {
 
     this.emitLog({ path, method, status: 'start' });
     try {
-      const response = await this.fetchImpl(`${SQUARE_ORIGIN}/${path}`, {
+      const response = await this.fetchImpl(`${GOQUAL_ORIGIN}/${path}`, {
         ...init,
         signal: controller.signal,
         headers: {
@@ -105,7 +111,7 @@ export class HejRestClient {
           authorization: `Bearer ${this.session.accessToken}`,
           'content-type': 'application/json;charset=UTF-8',
           cookie: `username=${this.session.usernameCookie}; autoLogin=true; JSESSIONID=${this.session.jsessionId}; accessToken=${this.session.accessToken}`,
-          Referer: `${SQUARE_ORIGIN}/list`,
+          Referer: `${GOQUAL_ORIGIN}/`,
           'x-requested-with': 'XMLHttpRequest',
           ...init.headers,
         },
@@ -143,4 +149,122 @@ export class HejRestClient {
   private emitLog(event: HejRestLogEvent): void {
     this.logger?.(event);
   }
+}
+
+function normalizeOpenApiDevices(payload: unknown): HejDevice[] {
+  return unwrapDeviceList(payload)
+    .map((entry) => normalizeDevice(entry))
+    .filter((device): device is HejDevice => device !== null);
+}
+
+function unwrapDeviceList(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    for (const key of ['result', 'devices', 'data']) {
+      if (Array.isArray(record[key])) {
+        return record[key];
+      }
+    }
+  }
+  return [];
+}
+
+function normalizeDevice(raw: unknown): HejDevice | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const entry = raw as Record<string, unknown>;
+  const id = stringValue(entry.id) ?? stringValue(entry.deviceId) ?? stringValue(entry.devId);
+  if (!id) {
+    return null;
+  }
+  const familyId = numberValue(entry.familyId) ?? numberValue(entry.family_id);
+  const roomId = numberValue(entry.roomId) ?? numberValue(entry.room_id);
+  const device: HejDevice = {
+    id,
+    name: stringValue(entry.name) ?? id,
+    deviceType: stringValue(entry.deviceType) ?? 'Unknown',
+    modelName: stringValue(entry.modelName) ?? null,
+    deviceState: isRecord(entry.deviceState) ? entry.deviceState : null,
+  };
+  if (typeof entry.hasSubDevices === 'boolean') {
+    device.hasSubDevices = entry.hasSubDevices;
+  }
+  if (familyId !== undefined) {
+    device.familyId = familyId;
+  }
+  const category = stringValue(entry.category);
+  if (category) {
+    device.category = category;
+  }
+  if (typeof entry.online === 'boolean') {
+    device.online = entry.online;
+  }
+  if (roomId !== undefined) {
+    device.roomId = roomId;
+  }
+  return device;
+}
+
+function familiesFromDevices(devices: HejDevice[]): HejFamily[] {
+  const families = new Map<number, HejFamily>();
+  for (const device of devices) {
+    const familyId = assignedFamilyId(device);
+    if (!families.has(familyId)) {
+      families.set(familyId, {
+        familyId,
+        name: familyId === HEJ_VIRTUAL_FAMILY_ID && device.familyId === undefined
+          ? HEJ_VIRTUAL_FAMILY_NAME
+          : `Home ${familyId}`,
+      });
+    }
+  }
+  if (families.size === 0) {
+    return [{ familyId: HEJ_VIRTUAL_FAMILY_ID, name: HEJ_VIRTUAL_FAMILY_NAME }];
+  }
+  return [...families.values()];
+}
+
+function roomsFromDevices(devices: HejDevice[], familyId: number): HejRoom[] {
+  const rooms = new Map<number, HejRoom>();
+  for (const device of devices) {
+    if (assignedFamilyId(device) !== familyId || typeof device.roomId !== 'number') {
+      continue;
+    }
+    if (!rooms.has(device.roomId)) {
+      rooms.set(device.roomId, {
+        room_id: device.roomId,
+        name: `Room ${device.roomId}`,
+      });
+    }
+  }
+  return [...rooms.values()];
+}
+
+function assignedFamilyId(device: HejDevice): number {
+  return typeof device.familyId === 'number' && Number.isFinite(device.familyId)
+    ? device.familyId
+    : HEJ_VIRTUAL_FAMILY_ID;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }

--- a/tests/hej-auth.test.ts
+++ b/tests/hej-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { HejAuthClient } from '../src/hej/auth.js';
+import { HejAuthClient, SQUARE_ORIGIN } from '../src/hej/auth.js';
 
 function jsonResponse(body: unknown, init: ResponseInit = {}) {
   return new Response(JSON.stringify(body), {
@@ -55,7 +55,11 @@ describe('HejAuthClient', () => {
     const events: unknown[] = [];
     const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
       const href = String(url);
-      if (href.endsWith('/oauth/login?vendor=shop')) {
+      if (href.endsWith('/oauth/login?vendor=openapi')) {
+        expect(init?.body).toBe('{}');
+        expect(init?.headers).toEqual(expect.objectContaining({
+          'content-type': 'application/json',
+        }));
         return new Response('', {
           status: 200,
           headers: {
@@ -64,17 +68,21 @@ describe('HejAuthClient', () => {
         });
       }
 
-      if (href.startsWith('https://square.hej.so/oauth/authorize')) {
+      if (href.startsWith('https://goqual.io/oauth/authorize')) {
+        expect(href).toContain('scope=shop');
+        expect(href).toContain(encodeURIComponent(`${SQUARE_ORIGIN}/list`));
+        expect(href).not.toContain('vendor=');
         return new Response('', {
           status: 302,
           headers: {
-            location: 'https://square.hej.so/list?code=auth-code',
+            location: `${SQUARE_ORIGIN}/list?code=auth-code`,
           },
         });
       }
 
       if (href.endsWith('/oauth/token')) {
         expect(init?.body?.toString()).toContain('grant_type=authorization_code');
+        expect(init?.body?.toString()).toContain(encodeURIComponent(`${SQUARE_ORIGIN}/list`));
         return jsonResponse({ access_token: 'access-token', expires_in: 86400 });
       }
 
@@ -104,5 +112,36 @@ describe('HejAuthClient', () => {
     ]));
     expect(JSON.stringify(events)).not.toContain('secret-password');
     expect(JSON.stringify(events)).not.toContain('user@example.test');
+  });
+
+  test('accepts an authorization code returned in the authorize response body', async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const href = String(url);
+      if (href.endsWith('/oauth/login?vendor=openapi')) {
+        return new Response('', {
+          status: 200,
+          headers: {
+            'set-cookie': `${'JSESSION'}ID=session-id; Path=/; HttpOnly`,
+          },
+        });
+      }
+      if (href.startsWith('https://goqual.io/oauth/authorize')) {
+        expect(href).toContain('scope=shop');
+        return new Response('auth-code', { status: 200 });
+      }
+      if (href.endsWith('/oauth/token')) {
+        return jsonResponse({ access_token: 'access-token', expires_in: 86400 });
+      }
+      throw new Error(`Unexpected request: ${href}`);
+    });
+    const client = new HejAuthClient({ fetch: fetchMock });
+
+    const session = await client.loginWithPassword({
+      identifier: 'user@example.test',
+      password: 'secret-password',
+    });
+
+    expect(session.accessToken).toBe('access-token');
+    expect(session.jsessionId).toBe('session-id');
   });
 });

--- a/tests/hej-rest.test.ts
+++ b/tests/hej-rest.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { HEJ_VIRTUAL_FAMILY_ID, HejRestClient } from '../src/hej/rest.js';
+import type { HejSession } from '../src/types.js';
+
+const session: HejSession = {
+  identifier: 'user@example.test',
+  autoLogin: true,
+  accessToken: 'access-token',
+  jsessionId: 'session-id',
+  usernameCookie: 'user%40example.test',
+  expiresAt: Date.now() + 86_400_000,
+};
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('HejRestClient', () => {
+  test('lists devices from the OpenAPI host and synthesizes a virtual home when family ids are absent', async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      expect(String(url)).toBe('https://goqual.io/openapi/devices');
+      return jsonResponse([
+        { id: 'light-1', name: 'Living light', deviceType: 'LightRgbw5', online: true },
+        { deviceId: 'plug-1', name: 'Desk plug', deviceType: 'Plug', deviceState: { power: true } },
+      ]);
+    });
+    const client = new HejRestClient(session, { fetch: fetchMock });
+
+    await expect(client.getFamilies()).resolves.toEqual([
+      { familyId: HEJ_VIRTUAL_FAMILY_ID, name: 'Hejhome' },
+    ]);
+    await expect(client.getDevices(HEJ_VIRTUAL_FAMILY_ID)).resolves.toEqual([
+      expect.objectContaining({
+        id: 'light-1',
+        name: 'Living light',
+        deviceType: 'LightRgbw5',
+        familyId: HEJ_VIRTUAL_FAMILY_ID,
+      }),
+      expect.objectContaining({
+        id: 'plug-1',
+        name: 'Desk plug',
+        deviceType: 'Plug',
+        familyId: HEJ_VIRTUAL_FAMILY_ID,
+      }),
+    ]);
+  });
+
+  test('groups OpenAPI devices by family and room when those fields are present', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      result: [
+        { id: 'a', name: 'A', deviceType: 'Plug', familyId: 10, roomId: 2 },
+        { id: 'b', name: 'B', deviceType: 'Plug', familyId: 10, roomId: 3 },
+        { id: 'c', name: 'C', deviceType: 'Plug', familyId: 11, roomId: 2 },
+      ],
+    }));
+    const client = new HejRestClient(session, { fetch: fetchMock });
+
+    await expect(client.getFamilies()).resolves.toEqual([
+      { familyId: 10, name: 'Home 10' },
+      { familyId: 11, name: 'Home 11' },
+    ]);
+    await expect(client.getRooms(10)).resolves.toEqual([
+      { room_id: 2, name: 'Room 2' },
+      { room_id: 3, name: 'Room 3' },
+    ]);
+    await expect(client.getDevices(10, 2)).resolves.toEqual([
+      expect.objectContaining({ id: 'a', familyId: 10, roomId: 2 }),
+    ]);
+  });
+
+  test('sends OpenAPI control commands with the requirments payload spelling', async () => {
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      expect(String(url)).toBe('https://goqual.io/openapi/control/light-1');
+      expect(init?.method).toBe('POST');
+      expect(init?.body).toBe(JSON.stringify({ requirments: { power: true } }));
+      return new Response('', { status: 200 });
+    });
+    const client = new HejRestClient(session, { fetch: fetchMock });
+
+    await client.controlDevice('light-1', { power: true });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## 요약
- 비밀번호 로그인, authorize, 토큰 교환을 `square.hej.so`에서 `https://goqual.io`로 바꿨습니다.
- 실제로 성공하는 authorize만 사용합니다. `redirect_uri=https://square.hej.so/list`, `scope=shop`.
- 기기 목록/제어는 `openapi/devices`, `openapi/control/{id}`를 쓰고, family API가 없으면 홈/룸을 기기 목록에서 파생합니다.

## 원인
`POST https://square.hej.so/oauth/login`이 443 포트에서 `ECONNREFUSED`로 거절됩니다. 그래서 2FA는 통과해도 로그인에서 끊깁니다. `2factor.goqual.com` 이메일 인증은 그대로 동작합니다.

실제로 되는 흐름은 아래와 같습니다.

1. `POST https://goqual.io/oauth/login?vendor=openapi` — Basic 인증, body `{}`
2. `GET https://goqual.io/oauth/authorize` — `redirect_uri=https://square.hej.so/list`, `scope=shop`
3. `POST https://goqual.io/oauth/token` — 같은 `redirect_uri`
4. 기기 목록/제어는 `https://goqual.io/openapi/*`

설정 UI와 플랫폼 discovery는 그대로입니다. 이미 `HejAuthClient` / `HejRestClient`를 호출합니다.

## 확인
- [x] OpenAPI 로그인·기기/제어 경로 단위 테스트 (`hej-auth`, `hej-rest`)
- [x] 이 PR 전에 `goqual.io`로 실제 로그인 및 스위치 제어 확인
- [ ] Homebridge 설정 UI: 2FA → 비밀번호 로그인 → 액세서리 표시
- [ ] 로그인 후 HomeKit에서 스위치 on/off

Fixes #41
